### PR TITLE
Remove SOQL requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This repository contains three simple classes that are invocable actions that ca
 
 Now this small package takes this pain away. Made possible by API48 release which allows Invocable Actions to take generic parameter types.
 
-Do note that the Process Builder version will use a SOQL query to retrieve the record (as Process Builder doesn't permit the record itself be passed as a parameter to the Action), while the Flow version doesn't have this restriction.
+Do note that neither the Process Builder version nor the Flow version will use a SOQL query to retrieve the record.

--- a/src/classes/SetRecordTypeIA.cls
+++ b/src/classes/SetRecordTypeIA.cls
@@ -7,17 +7,14 @@ public class SetRecordTypeIA {
         String RTDeveloperName = requestList[0].newRecordTypeDeveloperName;
         String objectName = requestList[0].objectName;
         
-        // get the record
-        // 
-        String query = 'SELECT Id FROM ' + objectName + ' WHERE ID = :recordIDToSetRTFor';
-        sObject sobj = Database.query(query);
-               
-        // get recordtypeid
+        SObject sobj = Schema.getGlobalDescribe().get(objectName).newSObject();
         
+        // get recordtypeid
         Schema.SObjectType s = sobj.getSObjectType();
         Schema.DescribeSObjectResult d = s.getDescribe();
         Id recordTypeId = d.getRecordTypeInfosByDeveloperName().get(RTDeveloperName).getRecordTypeId();
         
+        sobj.put('Id', recordIDToSetRTFor);
         sobj.put('RecordTypeId', recordTypeId);
         update sobj;
     }


### PR DESCRIPTION
With a dynamic SObject instantiation, we don't need a query in either version. Great code to start from!